### PR TITLE
1.1.10

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 ###> mediashare/marathon ###
-APP_VERSION=1.1.9
+APP_VERSION=1.1.10
 ###< mediashare/marathon ###
 
 ###> symfony/framework-bundle ###

--- a/bin/marathon
+++ b/bin/marathon
@@ -44,8 +44,8 @@ $commandsLoader = new \Symfony\Component\Console\CommandLoader\FactoryCommandLoa
     'task:archive' => function () use ($handlerService, $outputService) {
             return new Mediashare\Marathon\Command\TaskArchiveCommand($handlerService, $outputService);
         },
-    'task:delete' => function () use ($handlerService, $outputService) {
-            return new Mediashare\Marathon\Command\TaskDeleteCommand($handlerService, $outputService);
+    'task:delete' => function () use ($handlerService) {
+            return new Mediashare\Marathon\Command\TaskDeleteCommand($handlerService);
         },
     'commit' => function () use ($handlerService, $outputService) {
             return new Mediashare\Marathon\Command\CommitCommand($handlerService, $outputService);

--- a/src/Command/CommitCommand.php
+++ b/src/Command/CommitCommand.php
@@ -38,6 +38,9 @@ class CommitCommand extends Command {
 
     protected function execute(InputInterface $input, OutputInterface $output): int {
         try {
+            // Preload max width output
+            $this->outputService->setMaxWidthOfColumn();
+
             // Handler
             $this->handlerService->writeConfig(
                 $input->getOption('config-path'),

--- a/src/Command/CommitCommand.php
+++ b/src/Command/CommitCommand.php
@@ -65,6 +65,11 @@ class CommitCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Command/CommitDeleteCommand.php
+++ b/src/Command/CommitDeleteCommand.php
@@ -37,6 +37,9 @@ class CommitDeleteCommand extends Command {
 
     protected function execute(InputInterface $input, OutputInterface $output): int {
         try {
+            // Preload max width output
+            $this->outputService->setMaxWidthOfColumn();
+
             // Handler
             $this->handlerService->writeConfig(
                 $input->getOption('config-path'),

--- a/src/Command/CommitDeleteCommand.php
+++ b/src/Command/CommitDeleteCommand.php
@@ -63,6 +63,11 @@ class CommitDeleteCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Command/CommitEditCommand.php
+++ b/src/Command/CommitEditCommand.php
@@ -67,6 +67,11 @@ class CommitEditCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Command/CommitEditCommand.php
+++ b/src/Command/CommitEditCommand.php
@@ -39,6 +39,9 @@ class CommitEditCommand extends Command {
 
     protected function execute(InputInterface $input, OutputInterface $output): int {
         try {
+            // Preload max width output
+            $this->outputService->setMaxWidthOfColumn();
+
             // Handler
             $this->handlerService->writeConfig(
                 $input->getOption('config-path'),

--- a/src/Command/TaskArchiveCommand.php
+++ b/src/Command/TaskArchiveCommand.php
@@ -37,6 +37,9 @@ class TaskArchiveCommand extends Command {
     
     protected function execute(InputInterface $input, OutputInterface $output): int {
         try {
+            // Preload max width output
+            $this->outputService->setMaxWidthOfColumn();
+
             // Handler
             $this->handlerService->writeConfig(
                 $input->getOption('config-path'),

--- a/src/Command/TaskArchiveCommand.php
+++ b/src/Command/TaskArchiveCommand.php
@@ -64,6 +64,11 @@ class TaskArchiveCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Command/TaskDeleteCommand.php
+++ b/src/Command/TaskDeleteCommand.php
@@ -29,7 +29,6 @@ class TaskDeleteCommand extends Command {
 
     public function __construct(
         private readonly HandlerService $handlerService,
-        private readonly OutputService $outputService,
     ) {
         parent::__construct();
     }
@@ -44,14 +43,6 @@ class TaskDeleteCommand extends Command {
                 $input->getOption('config-task-dir'),
                 $input->getArgument('task-id'),
             )->taskDelete();
-
-            // Output render into terminal
-            $this->outputService
-                ->setOutput($output)
-                ->setConfig($this->handlerService->getConfig())
-                ->setTask($this->handlerService->getTask())
-                ->outputRenderCommits()
-                ->outputRenderTasks();
 
             // Update config
             $this->handlerService->updateTaskIdInConfig();

--- a/src/Command/TaskDeleteCommand.php
+++ b/src/Command/TaskDeleteCommand.php
@@ -63,6 +63,11 @@ class TaskDeleteCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Command/TaskListCommand.php
+++ b/src/Command/TaskListCommand.php
@@ -58,6 +58,11 @@ class TaskListCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Command/TaskListCommand.php
+++ b/src/Command/TaskListCommand.php
@@ -35,6 +35,9 @@ class TaskListCommand extends Command {
 
     protected function execute(InputInterface $input, OutputInterface $output): int {
         try {
+            // Preload max width output
+            $this->outputService->setMaxWidthOfColumn();
+
             // Handler
             $this->handlerService->writeConfig(
                 $input->getOption('config-path'),

--- a/src/Command/TaskStartCommand.php
+++ b/src/Command/TaskStartCommand.php
@@ -39,6 +39,9 @@ class TaskStartCommand extends Command {
 
     protected function execute(InputInterface $input, OutputInterface $output): int {
         try {
+            // Preload max width output
+            $this->outputService->setMaxWidthOfColumn();
+
             // Handler
             $this->handlerService->writeConfig(
                 $input->getOption('config-path'),

--- a/src/Command/TaskStartCommand.php
+++ b/src/Command/TaskStartCommand.php
@@ -68,6 +68,11 @@ class TaskStartCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Command/TaskStatusCommand.php
+++ b/src/Command/TaskStatusCommand.php
@@ -60,6 +60,11 @@ class TaskStatusCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Command/TaskStatusCommand.php
+++ b/src/Command/TaskStatusCommand.php
@@ -36,6 +36,9 @@ class TaskStatusCommand extends Command {
 
     protected function execute(InputInterface $input, OutputInterface $output): int {
         try {
+            // Preload max width output
+            $this->outputService->setMaxWidthOfColumn();
+
             // Handler
             $this->handlerService->writeConfig(
                 $input->getOption('config-path'),

--- a/src/Command/TaskStopCommand.php
+++ b/src/Command/TaskStopCommand.php
@@ -37,6 +37,9 @@ class TaskStopCommand extends Command {
     
     protected function execute(InputInterface $input, OutputInterface $output): int {
         try {
+            // Preload max width output
+            $this->outputService->setMaxWidthOfColumn();
+
             // Handler
             $this->handlerService->writeConfig(
                 $input->getOption('config-path'),

--- a/src/Command/TaskStopCommand.php
+++ b/src/Command/TaskStopCommand.php
@@ -61,6 +61,11 @@ class TaskStopCommand extends Command {
             $helper = new DescriptorHelper();
             $helper->describe($output, $this);
 
+            if ($this->handlerService->configService->isDebug()):
+                $output->writeln("");
+                $output->writeln($exception->getTraceAsString());
+            endif;
+
             return Command::FAILURE;
         }
     }

--- a/src/Entity/Config.php
+++ b/src/Entity/Config.php
@@ -76,7 +76,7 @@ class Config {
         return @timezone_open($this->dateTimeZone ?? self::DATETIME_ZONE);
     }
 
-    public function setTaskId(string $taskId): self {
+    public function setTaskId(string|null $taskId = null): self {
         $this->taskId = $taskId;
 
         return $this;

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -33,16 +33,16 @@ class ConfigService {
         string|null $dateTimeFormat = null,
         string|null $dateTimeZone = null,
         string|null $taskDirectory = null,
-        string|null $taskId = null,
+        string|false|null $taskId = null,
     ): self {
         $this->config = new Config(
             $configPath ?? $this->getLastConfigPath(),
         $dateTimeFormat ?? $this->getLastDateTimeFormat(),
         $dateTimeZone ?? $this->getLastDateTimeZone()->getName(),
             $taskDirectory = $taskDirectory ?? $this->getLastTaskDirectory(),
-            $taskId
-                ?? $this->getLastTaskId($taskDirectory)
-                ?? (new \DateTime())->format('YmdHis')
+            $taskId === false
+                ? null
+                : $taskId ?? $this->getLastTaskId(taskDirectory: $taskDirectory)
             ,
         );
 

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -115,7 +115,6 @@ class ConfigService {
     public function getLastTaskId(
         string|null $taskDirectory = null,
         string|null $excludeTaskId = null,
-        bool $onlyUnarchived = false,
     ): string|null {
         try {
             $lastTaskId = $this->taskService
@@ -124,18 +123,36 @@ class ConfigService {
                         ? $this->getLastConfig()->setTaskDirectory($taskDirectory)
                         : $this->getLastConfig()
                 )->getTasks()
-                ?->filter(static fn (Task $task) =>
-                    ($excludeTaskId !== null || $task->getId() !== $excludeTaskId)
-                    && ($onlyUnarchived !== false && $task->isArchived() === false)
-                )?->last()?->getId()
-            ;
+                ?->filter(static function (Task $task) use ($excludeTaskId) {
+                    $display = true;
+                    if ($task->getId() === $excludeTaskId):
+                        $display = false;
+                    endif;
+
+                    if ($task->isArchived() === true):
+                        $display = false;
+                    endif;
+
+                    return $display;
+                })?->last()?->getId();
+
 
             if ($lastTaskId):
                 return $lastTaskId;
             endif;
 
-            if ($lastTaskIdByLastConfig = $this->getLastConfig()->getTaskId()):
-                if (!$excludeTaskId || $lastTaskIdByLastConfig !== $excludeTaskId):
+            if (
+                ($lastTaskIdByLastConfig = $this->getLastConfig()->getTaskId())
+                && (
+                    !$excludeTaskId
+                    || $lastTaskIdByLastConfig !== $excludeTaskId
+                )
+            ):
+                $task = $this
+                    ->taskService
+                    ->setConfig($this->getLastConfig())
+                    ->getTask();
+                if ($task->isArchived() === false):
                     return $lastTaskIdByLastConfig;
                 endif;
             endif;

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -16,7 +16,7 @@ class ConfigService {
     private Config|null $config = null;
 
     public function __construct(
-        private TaskService $taskService,
+        private readonly TaskService $taskService,
     ) {
         $this->serializerService = new SerializerService();
         $this->filesystem = new Filesystem();

--- a/src/Service/HandlerService.php
+++ b/src/Service/HandlerService.php
@@ -18,7 +18,7 @@ class HandlerService {
     private Task|null $task = null;
 
     public function __construct(
-        private readonly ConfigService $configService,
+        public readonly ConfigService $configService,
         private readonly TaskService $taskService,
         private readonly CommitService $commitService,
         private readonly SerializerService $serializerService,

--- a/src/Service/HandlerService.php
+++ b/src/Service/HandlerService.php
@@ -54,19 +54,11 @@ class HandlerService {
 
     /**
      * @throws \JsonException
-     * @throws TaskNotFoundException
      */
     public function updateTaskIdInConfig(): self {
-        $this->taskService->setConfig(
-            $this->configService->setConfig(
-                taskId: $this
-                ->configService
-                ->getLastTaskId(
-                    excludeTaskId: $this->getConfig()->getTaskId(),
-                    onlyUnarchived: true,
-                ) ?? (new \DateTime())->format('YmdHis')
-            )->write()->getConfig()
-        )->create(['run' => false]);
+        $this->configService->setConfig(
+            taskId: false
+        )->write();
 
         return $this;
     }
@@ -129,7 +121,7 @@ class HandlerService {
         return $this->setTask(
             $this->taskService
                 ->setConfig($this->getConfig())
-                ->stop()
+                ->stop(createItIfNotExist: true)
                 ->getTask()
         )->writeTask();
     }

--- a/src/Service/OutputService.php
+++ b/src/Service/OutputService.php
@@ -63,7 +63,7 @@ class OutputService {
         return $this;
     }
 
-    private function getMaxWidthOfColumn(): int {
+    public function getMaxWidthOfColumn(): int {
         return $this->maxWidthOfColumn;
     }
 

--- a/src/Service/OutputService.php
+++ b/src/Service/OutputService.php
@@ -52,17 +52,19 @@ class OutputService {
         return $this->task;
     }
 
-    public function getMaxWidthOfColumn(): int {
-        if ($this->maxWidthOfColumn):
-            return $this->maxWidthOfColumn;
-        endif;
-
+    public function setMaxWidthOfColumn(): self {
         stripos(PHP_OS_FAMILY, 'WIN') === 0
             ? $terminalWidth = (int) shell_exec('powershell -Command "&{(Get-Host).UI.RawUI.WindowSize.Width}"')
             : $terminalWidth = (int) shell_exec('tput cols')
         ;
 
-        return $this->maxWidthOfColumn = $terminalWidth - ($terminalWidth / 1.33);
+        $this->maxWidthOfColumn = $terminalWidth - ($terminalWidth / 1.33);
+
+        return $this;
+    }
+
+    private function getMaxWidthOfColumn(): int {
+        return $this->maxWidthOfColumn;
     }
 
     public function outputRenderTasks(): self {

--- a/src/Service/TaskService.php
+++ b/src/Service/TaskService.php
@@ -105,13 +105,13 @@ class TaskService {
      * @throws TaskNotFoundException
      */
     public function start(
-        string|null $name = null,
-        string|null $duration = null,
+        string|false $name = false,
+        string|false $duration = false,
     ): self {
         $task = $this->getTask(createItIfNotExist: true)
             ->setRun(true)
             ->setArchived(false)
-            ->setName($name ?? $this->getTask()->getName());
+            ->setName($name === false ? $this->getTask()->getName() : $name);
 
         if ($duration):
             $firstStep = $task->getSteps()->first();

--- a/src/Service/TaskService.php
+++ b/src/Service/TaskService.php
@@ -125,7 +125,7 @@ class TaskService {
             );
         endif;
 
-        if (!$task->getStartDate() || (!($lastStep = $task->getSteps()?->last()) && $lastStep->getEndDate())):
+        if (!$task->getStartDate() || (!($lastStep = $task->getSteps()?->last()) || $lastStep->getEndDate())):
             $task
                 ->addStep(
                     $this->stepService->create()

--- a/src/Service/TaskService.php
+++ b/src/Service/TaskService.php
@@ -75,9 +75,6 @@ class TaskService {
         return $this;
     }
 
-    /**
-     * @throws TaskNotFoundException
-     */
     public function create(array $data = []): self {
         /** @var Task $task */
         $task = $this->serializerService->arrayToEntity($data, Task::class);
@@ -140,9 +137,9 @@ class TaskService {
      * @throws JsonDecodeException
      * @throws FileNotFoundException
      */
-    public function stop(): self {
+    public function stop(bool $createItIfNotExist = false): self {
         $task = $this
-            ->getTask(createItIfNotExist: true)
+            ->getTask($createItIfNotExist)
             ->setRun(false);
 
         if (($lastStep = $task->getSteps()?->last()) && !$lastStep->getEndDate()):
@@ -171,9 +168,6 @@ class TaskService {
         return $this;
     }
 
-    /**
-     * @throws TaskNotFoundException
-     */
     public function delete(): self {
         $this->filesystem
             ->remove($this->getTaskFilepath())
@@ -182,14 +176,7 @@ class TaskService {
         return $this->setTask(null);
     }
 
-    /**
-     * @throws TaskNotFoundException
-     */
     public function getTaskFilepath(): string {
-        if (!$this->getConfig()->getTaskId()):
-            throw new TaskNotFoundException();
-        endif;
-
-        return $this->getConfig()->getTaskDirectory().DIRECTORY_SEPARATOR. $this->getConfig()->getTaskId().'.json';
+        return $this->getConfig()->getTaskDirectory().DIRECTORY_SEPARATOR.$this->getConfig()->getTaskId().'.json';
     }
 }

--- a/src/Trait/EntityDateTimeTrait.php
+++ b/src/Trait/EntityDateTimeTrait.php
@@ -43,7 +43,7 @@ trait EntityDateTimeTrait {
         switch (self::class) {
             case Task::class:
                 if (
-                    $this->getSteps()->last()->getEndDate() !== null
+                    $this->getSteps()->last()?->getEndDate() !== null
                     && ($steps = $this
                         ->getSteps()
                         ->filter(static fn (Step $step) => $step->getEndDate())

--- a/src/Trait/EntityDateTimeTrait.php
+++ b/src/Trait/EntityDateTimeTrait.php
@@ -42,7 +42,13 @@ trait EntityDateTimeTrait {
 
         switch (self::class) {
             case Task::class:
-                if (($steps = $this->getSteps()->filter(static fn (Step $step) => $step->getEndDate()))->count() > 0):
+                if (
+                    $this->getSteps()->last()->getEndDate() !== null
+                    && ($steps = $this
+                        ->getSteps()
+                        ->filter(static fn (Step $step) => $step->getEndDate())
+                    )->count() > 0
+                ):
                     $endDate = $steps->last()->getEndDate();
                 elseif (($commits = $this->getCommits())->count() > 0):
                     $endDate = $commits->last()->getEndDate();

--- a/tests/Service/OutputServiceTest.php
+++ b/tests/Service/OutputServiceTest.php
@@ -116,6 +116,8 @@ class OutputServiceTest extends KernelTestCase {
 
         $expected = $actualWidthOfColumn - ($actualWidthOfColumn / 1.33);
 
+        $this->outputService->setMaxWidthOfColumn();
+
         $this->assertEquals((int) $expected, $this->outputService->getMaxWidthOfColumn());
     }
 }


### PR DESCRIPTION
- Fix EndDate of task displaying
- Fix `task:start` after `task:stop` used
- Displaying stack traces in debug mode
- Refactoring of `ConfigService::getLastTaskId` function
- Allow `null` value from taskId config 
- Preload max width column output for optimization